### PR TITLE
fix:  Removing \r from projection string

### DIFF
--- a/src/app/gcps-utils.service.ts
+++ b/src/app/gcps-utils.service.ts
@@ -13,6 +13,8 @@ export class GcpsUtilsService {
             projection = "EPSG:4326"; // default
         }
         
+        projection = projection.replace(/\r/g, '');
+
         if (projection.toLowerCase().startsWith("epsg:")){
             projection = projection.replace(/^EPSG:/ig, '');
         }


### PR DESCRIPTION
This commit allow to fix this bug : https://github.com/uav4geo/GCPEditorPro/issues/6
The only issue was for the projection string. It could not be recognize in the `defs.default` array because of the final \r.
After getting rid of it everything seems to work as expected (file is correctly loading even-if the gcp lines end with CRLF).