### PR TITLE
Fix automic naming of Ground Control Points

### DIFF
--- a/src/app/gcps-map/gcps-map.component.ts
+++ b/src/app/gcps-map/gcps-map.component.ts
@@ -210,8 +210,15 @@ https://a.tile.openstreetmap.org/{z}/{x}/{y}.png
                 const {lat, lng} = latlng;
                 const [x, y] = proj4.default(this.storage.projection.eq, [lng, lat]);
 
+                let counter = this.storage.gcps.length;
+                let name = 'gcp' + counter.toString().padStart(2, '0');
+                while (this.storage.gcps.some((gcp) => gcp.name === name)) {
+                    counter++;
+                    name = 'gcp' + counter.toString().padStart(2, '0');
+                }
+
                 this.storage.gcps.push({
-                    name: "gcp" + (this.storage.gcps.length + 1).toString().padStart(2, '0'),
+                    name: name,
                     northing:y,
                     easting: x,
                     elevation: NaN

--- a/src/app/gcps-utils.service.ts
+++ b/src/app/gcps-utils.service.ts
@@ -182,7 +182,12 @@ export class GcpsUtilsService {
                     if (matchingGcps.length === 0) {
 
                         // It generates something like gcp01 gcp02 ...
-                        imgGcp.gcpName = 'gcp' + (gcps.length + 1).toString().padStart(2, '0');
+                        let counter = gcps.length;
+                        imgGcp.gcpName = 'gcp' + counter.toString().padStart(2, '0');
+                        while (gcps.some((gcp) => gcp.name === imgGcp.gcpName)) {
+                            counter++;
+                            imgGcp.gcpName = 'gcp' + counter.toString().padStart(2, '0');
+                        }
 
                         gcps.push({
                             northing: imgGcp.geoY,


### PR DESCRIPTION
Proposed names for GCPs don't take into account that user can delete GCPs.
This patch guarantees GCP names are unique.

Solves ticket #24
