### PR TITLE
Untag images on GCP deletion

### DIFF
--- a/src/app/gcps-map/gcps-map.component.ts
+++ b/src/app/gcps-map/gcps-map.component.ts
@@ -252,6 +252,7 @@ https://a.tile.openstreetmap.org/{z}/{x}/{y}.png
             this.selectedGCP = null;
         }
 
+        this.storage.imageGcps = this.storage.imageGcps.filter(imgGcp => imgGcp.gcpName !== gcpName);
         this.storage.gcps = this.storage.gcps.filter(gcp => gcp.name !== gcpName);
         this.updateGcps();
     }


### PR DESCRIPTION
When deleting a Ground Control Point, images assigned to it must be untagged or the deleted GCP will make its way into gcp_list.txt.
