### PR TITLE
Precision Fix on large images

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcp-editor-pro",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "UAV4GEO",
     "email": "hello@uav4geo.com",

--- a/src/app/license-info/license-info.component.html
+++ b/src/app/license-info/license-info.component.html
@@ -1,4 +1,5 @@
 <div class="license-info" *ngIf="!storageService.getLicense().dev">
+    <div>Version 1.5.0</div>
     <div *ngIf="storageService.getLicense().demo">
         Demo mode. <a href="javascript:void(0)" (click)="enterLicense()">Activate</a> to unlock exports.
     </div>

--- a/src/app/license-info/license-info.component.html
+++ b/src/app/license-info/license-info.component.html
@@ -1,5 +1,5 @@
 <div class="license-info" *ngIf="!storageService.getLicense().dev">
-    <div>Version 1.5.0</div>
+    <div>Version 1.4.0</div>
     <div *ngIf="storageService.getLicense().demo">
         Demo mode. <a href="javascript:void(0)" (click)="enterLicense()">Activate</a> to unlock exports.
     </div>

--- a/src/app/smartimage/smartimage.component.ts
+++ b/src/app/smartimage/smartimage.component.ts
@@ -169,11 +169,16 @@ export class SmartimageComponent implements OnInit, AfterViewInit {
         const parentRect = this.img.nativeElement.parentElement.getClientRects()[0];
 
         const naturalWidth = this.img.nativeElement.naturalWidth;
+        const naturalHeight = this.img.nativeElement.naturalHeight;
+        
         const width = this.img.nativeElement.width;
-        const scale = width / naturalWidth;
+        const height = this.img.nativeElement.height;
+        
+        const scaleX = width / naturalWidth;
+        const scaleY = height / naturalHeight;
 
-        const left = (rect.left - parentRect.left) + this.pinLocationValue.x * scale * zoom;
-        const top = (rect.top - parentRect.top) + this.pinLocationValue.y * scale * zoom;
+        const left = (rect.left - parentRect.left) + this.pinLocationValue.x * scaleX * zoom;
+        const top = (rect.top - parentRect.top) + this.pinLocationValue.y * scaleY * zoom;
 
         return { x: left, y: top };
     }
@@ -189,7 +194,8 @@ export class SmartimageComponent implements OnInit, AfterViewInit {
         const naturalHeight = this.img.nativeElement.naturalHeight;
         const width = this.img.nativeElement.width;
         const height = this.img.nativeElement.height;
-        const scale = width / naturalWidth;
+        const scaleX = width / naturalWidth;
+        const scaleY = height / naturalHeight;
 
         const relx = e.clientX - rect.left;
         const rely = e.clientY - rect.top;
@@ -197,8 +203,8 @@ export class SmartimageComponent implements OnInit, AfterViewInit {
         const x = relx / zoom;
         const y = rely / zoom;
 
-        const realX = x / scale;
-        const realY = y / scale;
+        const realX = x / scaleX;
+        const realY = y / scaleY;
 
         return { x: realX, y: realY };
     }


### PR DESCRIPTION
Certain large images cause a precision issue when tagging GCPs due to a scale issue in the X/Y not being uniform when the web browser optimizes the size of image thumbnails. 

This PR fixes that.